### PR TITLE
Ignore aquifers with no code (fix #23)

### DIFF
--- a/sa_gwdata/waterconnect.py
+++ b/sa_gwdata/waterconnect.py
@@ -640,6 +640,7 @@ class WaterConnectSession:
         self.aquifers = {
             item["V"]: item["T"].replace((item["V"] + ": "), "")
             for item in response.json["Aquifer"]
+            if "V" in item
         }
         self.networks = {item["V"]: item["T"] for item in response.json["Networks"]}
         self.nrm_regions = {


### PR DESCRIPTION
Some stratigraphic units were redefined by DEM recently in SA Geodata leaving them with no map_symbol set, which meant the derived aquifer code will not have a code. This progated through to the "Aquifer" value under the GetAdvancedListsData request, where most entries should (and used to) have a "V" key and "T" value. Now some, such as "Nonning Rhyodacite" are missing a "V" key, leading to this error.

This commit filters those out until the underlying data can be fixed.