### PR TITLE
Fix for #28 - handle np.nan arg values for UnitNo and ObsNo constructors

### DIFF
--- a/sa_gwdata/identifiers.py
+++ b/sa_gwdata/identifiers.py
@@ -57,8 +57,9 @@ class UnitNo:
 
     def set(self, *args):
         """See :class:`UnitNo` constructor for details of arguments."""
+        args = list(args)
         if len(args) == 1:
-            if args[0] == "nan":
+            if args[0] == "nan" or pd.isnull(args[0]):
                 args[0] = None
             if args[0]:
                 if isinstance(args[0], list) or isinstance(args[0], tuple):
@@ -183,8 +184,9 @@ class ObsNo:
 
     def set(self, *args):
         """See :class:`ObsNo` constructor for details of arguments."""
+        args = list(args)
         if len(args) == 1:
-            if args[0] == "nan":
+            if args[0] == "nan" or pd.isnull(args[0]):
                 args[0] = None
             if args[0]:
                 if isinstance(args[0], list) or isinstance(args[0], tuple):

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -6,6 +6,7 @@ import pytest
 
 from sa_gwdata.identifiers import ObsNo, UnitNo, Well
 
+import numpy as np
 
 def test_accept_empty_unit_no():
     UnitNo()
@@ -198,3 +199,6 @@ def test_well_bool():
 
 def test_well_with_property_kwarg():
     well = Well(203536, unit_no=662711249, unit_hyphen="6627-11249")
+
+def test_well_with_numpy_nans():
+    well = Well(6945, unit_hyphen="5842-16", obs_no=np.nan)


### PR DESCRIPTION
Uses pd.isnull to convert any np.nans to None