### PR TITLE
Retry on ConnectionError

### DIFF
--- a/sa_gwdata/waterconnect.py
+++ b/sa_gwdata/waterconnect.py
@@ -157,7 +157,11 @@ class WaterConnectSession:
             path = self.endpoint + path
         path = path.format(app=app)
         logger.debug("GET {} verify={}".format(path, verify))
-        response = requests.get(path, verify=verify, **kwargs)
+        try:
+            response = requests.get(path, verify=verify, **kwargs)
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.8)
+            response = requests.get(path, verify=verify, **kwargs)
         self.last_request = time.time()
         endpoint, name = path.rsplit("/", 1)
         logger.debug("Response content = {}".format(response.content))


### PR DESCRIPTION
Sometimes waterconnect.sa.gov.au drops the connection. For at least the first occasion, this commit waits 0.8 second and then retries. If it gets raised again, we propagate the exception and fail - the user will have to decide whether to try again or not.